### PR TITLE
Add ability to disable icon rotation and complete animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ A simple *Slide to Unlock* **Material** widget for **Android**, written in [**Ko
         * [``slider_height``](#slider_height)
         * [``slider_locked``](#slider_locked)
         * [``slider_icon``](#slider_icon)
+        * [``rotate_icon``](#rotate_icon)
+        * [``animation_complete``](#animation_complete)
         * [``android:elevation``](#androidelevation)
     * [Event callbacks](#event-callbacks)
 * [Demo](#demo-)
@@ -156,7 +158,7 @@ sta.setLocked(true);
 
 #### ``slider_icon``
 
-You can set a custom icon by setting the ``slider_icon``attribute to a drawable resource.
+You can set a custom icon by setting the ``slider_icon`` attribute to a drawable resource.
 
 <p align="center">
   <img src="assets/custom_icon.png" alt="custom_icon" width="40%"/>
@@ -166,6 +168,19 @@ You can set a custom icon by setting the ``slider_icon``attribute to a drawable 
 app:slider_icon="@drawable/custom_icon"
 ```
 
+You can also disable the rotation by setting the ``rotate_icon`` attribute to false.
+
+```xml
+app:rotate_icon="false"
+```
+
+#### ``animate_complete``
+
+You might want to disable the slider complete animation. Do this by setting the ``app:animate_complete`` attribute to false
+
+```xml
+app:animate_complete="false"
+```
 
 #### ``android:elevation``
 

--- a/slidetoact/src/main/res/values/attrs.xml
+++ b/slidetoact/src/main/res/values/attrs.xml
@@ -15,6 +15,8 @@
         <attr name="slider_height" format="dimension" />
         <attr name="slider_locked" format="boolean" />
         <attr name="slider_icon" format="reference" />
+        <attr name="rotate_icon" format="boolean" />
+        <attr name="animate_complete" format="boolean" />
     </declare-styleable>
     <declare-styleable name="SlideToActViewTheme">
         <attr name="slideToActViewStyle" format="reference"/>


### PR DESCRIPTION
- rotate_icon to enable or disable icon rotation while sliding
- animate_complete to enable or disable animation when slide is complete

## Status
**READY**

## Description
Add the ability to disable icon rotation, and the ability to disable the animation that occurs when slide is completed.

## Related PRs/Issues
N.A

## Todos
- [ ] Tests
- [✓] Documentation
- [ ] Screenshots

## Feedback Reviews

@cortinico