### PR TITLE
Add ability to disable icon rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A simple *Slide to Unlock* **Material** widget for **Android**, written in [**Ko
         * [``slider_height``](#slider_height)
         * [``slider_locked``](#slider_locked)
         * [``slider_icon``](#slider_icon)
+        * [``rotate_icon``](#rotate_icon)
         * [``android:elevation``](#androidelevation)
     * [Event callbacks](#event-callbacks)
 * [Demo](#demo-)
@@ -166,6 +167,15 @@ You can set a custom icon by setting the ``slider_icon``attribute to a drawable 
 app:slider_icon="@drawable/custom_icon"
 ```
 
+You can also disable the rotation by setting the ``rotate_icon`` attribute to false.
+ ```xml
+app:rotate_icon="false"
+```
+ #### ``animate_complete``
+ You might want to disable the slider complete animation. Do this by setting the ``app:animate_complete`` attribute to false
+ ```xml
+app:animate_complete="false"
+```
 
 #### ``android:elevation``
 

--- a/README.md
+++ b/README.md
@@ -168,14 +168,6 @@ app:slider_icon="@drawable/custom_icon"
 ```
 
 You can also disable the rotation by setting the ``rotate_icon`` attribute to false.
- ```xml
-app:rotate_icon="false"
-```
- #### ``animate_complete``
- You might want to disable the slider complete animation. Do this by setting the ``app:animate_complete`` attribute to false
- ```xml
-app:animate_complete="false"
-```
 
 #### ``android:elevation``
 

--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -170,6 +170,9 @@ class SlideToActView(context: Context,
     /** Public flag to lock the slider */
     var isLocked = false
 
+    /** Public flag to lock the rotation icon */
+    var isRotateIcon = true
+
     /** Public Slide event listeners */
     var onSlideToActAnimationEventListener: OnSlideToActAnimationEventListener? = null
     var onSlideCompleteListener: OnSlideCompleteListener? = null
@@ -196,6 +199,7 @@ class SlideToActView(context: Context,
             typeFace = layoutAttrs.getInt(R.styleable.SlideToActView_text_style, 0)
 
             isLocked = layoutAttrs.getBoolean(R.styleable.SlideToActView_slider_locked, false)
+            isRotateIcon = layoutAttrs.getBoolean(R.styleable.SlideToActView_rotate_icon, true)
 
             mTextSize = layoutAttrs.getDimensionPixelSize(R.styleable.SlideToActView_text_size, resources.getDimensionPixelSize(R.dimen.default_text_size))
             mOriginAreaMargin = layoutAttrs.getDimensionPixelSize(R.styleable.SlideToActView_area_margin, resources.getDimensionPixelSize(R.dimen.default_area_margin))
@@ -309,7 +313,10 @@ class SlideToActView(context: Context,
             mDrawableArrow.bounds.top <= mDrawableArrow.bounds.bottom) {
             mDrawableArrow.draw(canvas)
         }
-        canvas.rotate(-1 * mArrowAngle, mInnerRect.centerX(), mInnerRect.centerY())
+
+        if (isRotateIcon) {
+            canvas.rotate(-1 * mArrowAngle, mInnerRect.centerX(), mInnerRect.centerY())
+        }
 
         // Tick drawing
         mDrawableTick.setBounds(

--- a/slidetoact/src/main/res/values/attrs.xml
+++ b/slidetoact/src/main/res/values/attrs.xml
@@ -15,6 +15,7 @@
         <attr name="slider_height" format="dimension" />
         <attr name="slider_locked" format="boolean" />
         <attr name="slider_icon" format="reference" />
+        <attr name="rotate_icon" format="boolean" />
     </declare-styleable>
     <declare-styleable name="SlideToActViewTheme">
         <attr name="slideToActViewStyle" format="reference"/>


### PR DESCRIPTION
- rotate_icon to enable or disable icon rotation while sliding

## Status
**READY**

## Description
Allow disabling of icon rotation in the slider

## Related PRs/Issues
#21 

## Todos
- [ ] Tests
- [x] Documentation
- [ ] Screenshots

## Feedback Reviews

@cortinico