### PR TITLE
Fix after PR #22 - a couple of lines needed an if isRotateIcon as well

### DIFF
--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -303,8 +303,10 @@ class SlideToActView(context: Context,
         canvas.drawText(text.toString(), mTextXPosition, mTextYPosition, mTextPaint)
 
         // Arrow angle
-        mArrowAngle = -180 * mPositionPerc
-        canvas.rotate(mArrowAngle, mInnerRect.centerX(), mInnerRect.centerY())
+        if (isRotateIcon) {
+            mArrowAngle = -180 * mPositionPerc
+            canvas.rotate(mArrowAngle, mInnerRect.centerX(), mInnerRect.centerY())
+        }
         mDrawableArrow.setBounds(mInnerRect.left.toInt() + mArrowMargin,
             mInnerRect.top.toInt() + mArrowMargin,
             mInnerRect.right.toInt() - mArrowMargin,


### PR DESCRIPTION
## Status
**READY**

## Description
The is a fix after PR #22 went int. A couple of additional lines had to be check for isRotateIcon as well.
Without this fix, Tick drawing on "slider complete" never took place. That's how I noticed something was missing.

## Related PRs/Issues
PR #22 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Screenshots

## Feedback Reviews

@cortinico