### PR TITLE
Remove Emulator setup from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,5 @@ android:
     - extra-android-m2repository
     - extra-google-m2repository
 
-before_script:
-  - echo no | android create avd --force -n test -t "android-"$EMULATOR_API_LEVEL --abi armeabi-v7a --skin 480x800
-  - emulator -avd test -no-audio -no-window &
-  - android-wait-for-emulator
-  - adb shell input keyevent 82 &
-
 script:
-   - ./gradlew clean build lint test connectedCheck
+   - ./gradlew clean build lint test


### PR DESCRIPTION
## Description
Turns out Travis is really flaky recently and can't run an Android emulator.
Disabling the `connectedTests` (at least for now) :/