### PR TITLE
Add Switch Behavior to SlideToAct

### DIFF
--- a/example/src/main/res/layout/content_reversed_slider.xml
+++ b/example/src/main/res/layout/content_reversed_slider.xml
@@ -17,5 +17,19 @@
             app:slider_reversed="true"
             app:text="Reversed Slider" />
 
+        <com.ncorti.slidetoact.SlideToActView
+            android:id="@+id/slide_animate_completion_off"
+            style="@style/SlideToActView.Example"
+            app:animate_completion="false"
+            app:text="Slider that doesn't complete" />
+
+        <com.ncorti.slidetoact.SlideToActView
+            android:id="@+id/slide_animate_completion_off_and_text"
+            style="@style/SlideToActView.Example"
+            app:animate_completion="false"
+            app:compete_text="...and has a complete_text!"
+            app:text="Slider that doesn't complete..." />
+
+
     </LinearLayout>
 </ScrollView>

--- a/example/src/main/res/layout/content_reversed_slider.xml
+++ b/example/src/main/res/layout/content_reversed_slider.xml
@@ -27,7 +27,7 @@
             android:id="@+id/slide_animate_completion_off_and_text"
             style="@style/SlideToActView.Example"
             app:animate_completion="false"
-            app:compete_text="...and has a complete_text!"
+            app:complete_text="...and has a complete_text!"
             app:text="Slider that doesn't complete..." />
 
 

--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -276,7 +276,7 @@ class SlideToActView @JvmOverloads constructor (
             }
 
             text = layoutAttrs.getString(R.styleable.SlideToActView_text) ?: ""
-            completeText = layoutAttrs.getString(R.styleable.SlideToActView_compete_text) ?: ""
+            completeText = layoutAttrs.getString(R.styleable.SlideToActView_complete_text) ?: ""
             typeFace = layoutAttrs.getInt(R.styleable.SlideToActView_text_style, 0)
             mTextSize = layoutAttrs.getDimensionPixelSize(R.styleable.SlideToActView_text_size, resources.getDimensionPixelSize(R.dimen.slidetoact_default_text_size))
             textColor = actualTextColor

--- a/slidetoact/src/main/res/values/attrs.xml
+++ b/slidetoact/src/main/res/values/attrs.xml
@@ -20,6 +20,7 @@
         <attr name="slider_icon_color" format="color"/>
         <attr name="rotate_icon" format="boolean" />
         <attr name="animate_completion" format="boolean" />
+        <attr name="compete_text" format="string" />
         <attr name="text_appearance" format="reference" />
     </declare-styleable>
     <declare-styleable name="SlideToActViewTheme">

--- a/slidetoact/src/main/res/values/attrs.xml
+++ b/slidetoact/src/main/res/values/attrs.xml
@@ -20,7 +20,7 @@
         <attr name="slider_icon_color" format="color"/>
         <attr name="rotate_icon" format="boolean" />
         <attr name="animate_completion" format="boolean" />
-        <attr name="compete_text" format="string" />
+        <attr name="complete_text" format="string" />
         <attr name="text_appearance" format="reference" />
     </declare-styleable>
     <declare-styleable name="SlideToActViewTheme">


### PR DESCRIPTION
## Description

Improved the logic behind the `animate_completion` attribute in order to
let the slider behave as a switch. Now the switch can be animated back
with a drag and the value of `isCompleted` is now consistent.

Moreover added the `complete_text` to provide a second @string to show
when the slider is complete. If provided, the slider will crossfade
between the two strings.

## Screenshot
![May-17-2019 01-24-29](https://user-images.githubusercontent.com/3001957/57893546-b2d5aa80-7843-11e9-9812-96ea81def176.gif)

## Related PRs/Issues
Fixes #72 
Ping @Erinel