### PR TITLE
Fixed animDuration access syntax in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,11 @@ Use the ``slider_locked`` attribute to **lock the slider** (this is a boolean at
 
 Use the ``animation_duration`` attribute to **set the duration** of the complete and reset animation (in milliseconds).
 
-You can also toggle this attribute programmatically with the provided setter.
+You can also toggle this attribute programmatically with the provided property.
 
 ```kotlin
 val sta = (SlideToActView) findViewById(R.id.slider);
-sta.animDuration(600)
+sta.animDuration = 600
 ```
 
 <p align="center">


### PR DESCRIPTION
animDuration is not actually a function or setter but a property. So, the property access syntax should be used, right?

## Related PRs/Issues
animDuration was added in PR #83 