### PR TITLE
Replaced the deprecated overload of invalidate with the no-arg overload

### DIFF
--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -462,7 +462,7 @@ class SlideToActView @JvmOverloads constructor (
                         positionAnimator.duration = animDuration
                         positionAnimator.addUpdateListener {
                             mPosition = it.animatedValue as Int
-                            invalidateArea()
+                            invalidate()
                         }
                         positionAnimator.start()
                     } else if (mPosition > 0 && mPositionPerc >= mGraceValue) {
@@ -481,17 +481,13 @@ class SlideToActView @JvmOverloads constructor (
                         val diffX = event.x - mLastX
                         mLastX = event.x
                         increasePosition(diffX.toInt())
-                        invalidateArea()
+                        invalidate()
                     }
                 }
             }
             return true
         }
         return super.onTouchEvent(event)
-    }
-
-    private fun invalidateArea() {
-        invalidate(mOuterRect.left.toInt(), mOuterRect.top.toInt(), mOuterRect.right.toInt(), mOuterRect.bottom.toInt())
     }
 
     /**
@@ -530,14 +526,14 @@ class SlideToActView @JvmOverloads constructor (
         val finalPositionAnimator = ValueAnimator.ofInt(mPosition, mAreaWidth - mAreaHeight)
         finalPositionAnimator.addUpdateListener {
             mPosition = it.animatedValue as Int
-            invalidateArea()
+            invalidate()
         }
 
         // Animator that bounce away the cursors
         val marginAnimator = ValueAnimator.ofInt(mActualAreaMargin, (mInnerRect.width() / 2).toInt() + mActualAreaMargin)
         marginAnimator.addUpdateListener {
             mActualAreaMargin = it.animatedValue as Int
-            invalidateArea()
+            invalidate()
         }
         marginAnimator.interpolator = AnticipateOvershootInterpolator(2f)
 
@@ -548,7 +544,7 @@ class SlideToActView @JvmOverloads constructor (
             if (Build.VERSION.SDK_INT >= 21) {
                 invalidateOutline()
             }
-            invalidateArea()
+            invalidate()
         }
 
         val tickAnimator: ValueAnimator
@@ -559,7 +555,7 @@ class SlideToActView @JvmOverloads constructor (
                 mTickMargin = mIconMargin
                 mFlagDrawTick = true
                 mDrawableTick.alpha = it.animatedValue as Int
-                invalidateArea()
+                invalidate()
             }
         } else {
             // Used AVD Animation.
@@ -569,7 +565,7 @@ class SlideToActView @JvmOverloads constructor (
                     mTickMargin = mIconMargin
                     mFlagDrawTick = true
                     startTickAnimation()
-                    invalidateArea()
+                    invalidate()
                 }
             }
         }
@@ -646,7 +642,7 @@ class SlideToActView @JvmOverloads constructor (
         val tickAnimator = ValueAnimator.ofInt(mTickMargin, mAreaWidth / 2)
         tickAnimator.addUpdateListener {
             mTickMargin = it.animatedValue as Int
-            invalidateArea()
+            invalidate()
         }
 
         // Animator that enlarges the outer area
@@ -658,20 +654,20 @@ class SlideToActView @JvmOverloads constructor (
             if (Build.VERSION.SDK_INT >= 21) {
                 invalidateOutline()
             }
-            invalidateArea()
+            invalidate()
         }
 
         val positionAnimator = ValueAnimator.ofInt(mPosition, 0)
         positionAnimator.addUpdateListener {
             mPosition = it.animatedValue as Int
-            invalidateArea()
+            invalidate()
         }
 
         // Animator that re-draw the cursors
         val marginAnimator = ValueAnimator.ofInt(mActualAreaMargin, mOriginAreaMargin)
         marginAnimator.addUpdateListener {
             mActualAreaMargin = it.animatedValue as Int
-            invalidateArea()
+            invalidate()
         }
         marginAnimator.interpolator = AnticipateOvershootInterpolator(2f)
 
@@ -679,7 +675,7 @@ class SlideToActView @JvmOverloads constructor (
         val arrowAnimator = ValueAnimator.ofInt(mArrowMargin, mIconMargin)
         arrowAnimator.addUpdateListener {
             mArrowMargin = it.animatedValue as Int
-            invalidateArea()
+            invalidate()
         }
 
 


### PR DESCRIPTION
## Description
The invalidate(int, int, int, int) overload was deprecated in API level 28. Android doc encourages to use invalidate() instead.

> The switch to hardware accelerated rendering in API 14 reduced the importance of the dirty rectangle. In API 21 the given rectangle is ignored entirely in favor of an internally-calculated area instead. Because of this, clients are encouraged to just call invalidate().
[Documentation](https://developer.android.com/reference/android/view/View.html#invalidate(int,%20int,%20int,%20int))