### PR TITLE
Relax the requirement on Complete Icon being an AVD

### DIFF
--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActIconUtil.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActIconUtil.kt
@@ -1,0 +1,119 @@
+package com.ncorti.slidetoact
+
+import android.animation.ValueAnimator
+import android.content.Context
+import android.graphics.drawable.AnimatedVectorDrawable
+import android.graphics.drawable.Drawable
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.LOLLIPOP
+import android.os.Build.VERSION_CODES.N
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.DrawableCompat
+import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat
+
+internal object SlideToActIconUtil {
+
+    internal fun loadIconCompat(context: Context, value: Int): Drawable {
+        // Due to bug in the AVD implementation in the support library, we use it only for API < 21
+        return if (SDK_INT >= LOLLIPOP) {
+            context.resources.getDrawable(value, context.theme)
+        } else {
+            return AnimatedVectorDrawableCompat.create(context, value)
+                ?: ContextCompat.getDrawable(context, value)!!
+        }
+    }
+
+    internal fun tintIconCompat(icon: Drawable, color: Int) {
+        // Tinting the tick with the proper implementation method
+        when {
+            SDK_INT >= LOLLIPOP -> {
+                icon.setTint(color)
+            }
+            icon is AnimatedVectorDrawableCompat -> {
+                (icon as AnimatedVectorDrawableCompat).setTint(color)
+            }
+            else -> {
+                DrawableCompat.setTint(icon, color)
+            }
+        }
+    }
+
+    /**
+     * Internal method to start the Icon AVD animation, with the proper library based on API level.
+     */
+    private fun startIconAnimation(icon: Drawable) {
+        when {
+            SDK_INT >= LOLLIPOP && icon is AnimatedVectorDrawable -> {
+                icon.start()
+            }
+            icon is AnimatedVectorDrawableCompat -> {
+                (icon as AnimatedVectorDrawableCompat).start()
+            }
+            else -> {
+                // Do nothing as the icon can't be animated
+            }
+        }
+    }
+
+    /**
+     * Internal method to stop the Icon AVD animation, with the proper library based on API level.
+     */
+    internal fun stopIconAnimation(icon: Drawable) {
+        when {
+            SDK_INT >= LOLLIPOP && icon is AnimatedVectorDrawable -> {
+                icon.stop()
+            }
+            icon is AnimatedVectorDrawableCompat -> {
+                (icon as AnimatedVectorDrawableCompat).stop()
+            }
+            else -> {
+                // Do nothing as the icon can't be animated
+            }
+        }
+    }
+
+    /**
+     * Creates a [ValueAnimator] to animate the complete icon. Uses the [fallbackToFadeAnimation]
+     * to decide if the icon should be animated with a Fade or with using [AnimatedVectorDrawable].
+     */
+    fun createIconAnimator(
+        view: SlideToActView,
+        icon: Drawable,
+        listener: ValueAnimator.AnimatorUpdateListener
+    ): ValueAnimator {
+        if (fallbackToFadeAnimation(icon)) {
+            // Fallback not using AVD.
+            val tickAnimator = ValueAnimator.ofInt(0, 255)
+            tickAnimator.addUpdateListener(listener)
+            tickAnimator.addUpdateListener {
+                icon.alpha = it.animatedValue as Int
+                view.invalidate()
+            }
+            return tickAnimator
+        } else {
+            // Used AVD Animation.
+            val tickAnimator = ValueAnimator.ofInt(0)
+            var startedOnce = false
+            tickAnimator.addUpdateListener(listener)
+            tickAnimator.addUpdateListener {
+                if (!startedOnce) {
+                    startIconAnimation(icon)
+                    view.invalidate()
+                    startedOnce = true
+                }
+            }
+            return tickAnimator
+        }
+    }
+
+    /**
+     * Logic to decide if we should do a Fade or use the [AnimatedVectorDrawable] animation.
+     */
+    private fun fallbackToFadeAnimation(icon: Drawable) = when {
+        // We don't use AVD at all for <= N.
+        SDK_INT <= N -> true
+        SDK_INT >= LOLLIPOP && icon !is AnimatedVectorDrawable -> true
+        SDK_INT < LOLLIPOP && icon !is AnimatedVectorDrawableCompat -> true
+        else -> false
+    }
+}

--- a/slidetoact/src/main/res/drawable-v25/slidetoact_ic_check.xml
+++ b/slidetoact/src/main/res/drawable-v25/slidetoact_ic_check.xml
@@ -3,6 +3,13 @@
     android:height="24dp"
     android:viewportHeight="48.0"
     android:viewportWidth="48.0">
+
+    <!--
+    Please note that this icon has trimPathEnd set to 0 as the library is animating it
+    with an AnimatedVectorDrawable. For API < 25 trimPathEnd is not set as we just
+    fade in the Icon (though we need it visible
+    -->
+
     <path
         android:name="check"
         android:fillColor="#00000000"

--- a/slidetoact/src/main/res/drawable/slidetoact_ic_check.xml
+++ b/slidetoact/src/main/res/drawable/slidetoact_ic_check.xml
@@ -8,6 +8,5 @@
         android:fillColor="#00000000"
         android:pathData="m7.21,25.35l10.3,10.37l23.29,-23.43"
         android:strokeColor="#FFFFFF"
-        android:strokeWidth="3.5"
-        android:trimPathStart="0.01" />
+        android:strokeWidth="3.5"/>
 </vector>


### PR DESCRIPTION
## Description
I'm refactoring the code to load the AnimatedVectorDrawable in a separate file.

Moreover I'm adding the possibility to specify any drawable as a complete icon. Previously the library will just crash if you don't provide an `AVD`. Now you can provide any drawable and it will be faded:

![Jul-10-2020 19-48-15](https://user-images.githubusercontent.com/3001957/87192642-2fa0cf00-c2f7-11ea-9af0-eded11de8c40.gif)

## Related PRs/Issues
#14 