### PR TITLE
Fix OnClickListener not being called on complete status

### DIFF
--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -533,6 +533,10 @@ class SlideToActView @JvmOverloads constructor(
     }
 
     override fun onTouchEvent(event: MotionEvent?): Boolean {
+        if (event != null && event.action == MotionEvent.ACTION_DOWN) {
+            // Calling performClick on every ACTION_DOWN so OnClickListener is triggered properly.
+            performClick()
+        }
         if (event != null && isEnabled) {
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
@@ -544,7 +548,6 @@ class SlideToActView @JvmOverloads constructor(
                         // Clicking outside the area -> User failed, notify the listener.
                         onSlideUserFailedListener?.onSlideFailed(this, true)
                     }
-                    performClick()
                 }
                 MotionEvent.ACTION_UP -> {
                     parent.requestDisallowInterceptTouchEvent(false)


### PR DESCRIPTION
## Description
Currently `performClick` is fired only on `ACTION_DOWN` events when the widget is enabled (i.e. is not completed). I'm updating the logic to make sure we always fire the `OnClickListener` when the widget is clicked.

## Related PRs/Issues
Fixes #141 