### PR TITLE
Flip instead of rotating it when reversed

### DIFF
--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -511,10 +511,10 @@ class SlideToActView @JvmOverloads constructor(
         // We compute the rotation of the arrow and we apply .rotate transformation on the canvas.
         canvas.save()
         if (isReversed) {
-            canvas.rotate(180f, mInnerRect.centerX(), mInnerRect.centerY())
+            canvas.scale(-1F, 1F, mInnerRect.centerX(), mInnerRect.centerY())
         }
         if (isRotateIcon) {
-            mArrowAngle = 180 * mPositionPerc * (if (isReversed) 1 else -1)
+            mArrowAngle = -180 * mPositionPerc
             canvas.rotate(mArrowAngle, mInnerRect.centerX(), mInnerRect.centerY())
         }
         mDrawableArrow.setBounds(


### PR DESCRIPTION
**Please note: If you were using `slider_icon` and `slider_reversed` and you were applying a 180 degree rotation, make sure you remove the extra rotation or your icon will be flipped in the upcoming versions**

## Description
This fixes a bug that happened with `slider_icon` and `slider_reversed`. Users that were specifying both had to manually provide a rotated image as the library will perform a 180 degree rotation.

The fix is to flip the image instead of rotating the image.

| Before | After |
| -- | -- |
|  ![Screenshot_1611950364](https://user-images.githubusercontent.com/3001957/106321730-0042b700-6275-11eb-9d14-fd5286d8d00b.png) | ![Screenshot_1611950331](https://user-images.githubusercontent.com/3001957/106321690-f15c0480-6274-11eb-90c4-2d1160388f26.png) | 

## Related PRs/Issues
Fixes #150 