### PR TITLE
Added attributes to enable icons without tint color and grace value modification

### DIFF
--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -22,8 +22,6 @@
             android:id="@+id/welcome_slider"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            android:elevation="6dp"
             app:text="Sample SlideToActView" />
 
         <TextView

--- a/slidetoact/src/main/res/values/attrs.xml
+++ b/slidetoact/src/main/res/values/attrs.xml
@@ -15,11 +15,14 @@
         <attr name="text_color" format="color" />
         <attr name="border_radius" format="dimension" />
         <attr name="slider_height" format="dimension" />
+        <attr name="grace_value_percent" format="float" />
         <attr name="animation_duration" format="integer" />
         <attr name="bump_vibration" format="integer" />
         <attr name="slider_locked" format="boolean" />
         <attr name="slider_reversed" format="boolean" />
         <attr name="slider_icon" format="reference" />
+        <attr name="enable_tint_slider_icon" format="boolean" />
+        <attr name="enable_tint_complete_icon" format="boolean" />
         <attr name="slider_icon_color" format="color" />
         <attr name="rotate_icon" format="boolean" />
         <attr name="animate_completion" format="boolean" />

--- a/slidetoact/src/main/res/values/attrs.xml
+++ b/slidetoact/src/main/res/values/attrs.xml
@@ -11,7 +11,11 @@
         <attr name="area_margin" format="dimension" />
         <attr name="icon_margin" format="dimension" />
         <attr name="inner_color" format="color" />
+        <attr name="inner_stroke_color" format="color" />
+        <attr name="inner_stroke_width" format="dimension" />
         <attr name="outer_color" format="color" />
+        <attr name="outer_stroke_color" format="color" />
+        <attr name="outer_stroke_width" format="dimension" />
         <attr name="text_color" format="color" />
         <attr name="border_radius" format="dimension" />
         <attr name="slider_height" format="dimension" />

--- a/slidetoact/src/main/res/values/dimens.xml
+++ b/slidetoact/src/main/res/values/dimens.xml
@@ -1,5 +1,6 @@
 <resources>
     <dimen name="slidetoact_default_area_margin">8dp</dimen>
+    <dimen name="slidetoact_default_stroke_width">3dp</dimen>
     <dimen name="slidetoact_default_icon_margin">16dp</dimen>
     <dimen name="slidetoact_default_text_size">16sp</dimen>
 </resources>


### PR DESCRIPTION
- Enable slider and complete icon tint
- Added enable_tint_complete_icon and enable_tint_slider_icon attr
- Grace value made public to modificate its value
- Added grace_value_percent attr
- Change AnticipateOvershootInterpolar to LinearInterpolator to avoid weird animation effect when slider dissappear on completion

