### PR TITLE
Enable/Disable options for slider and complete icon color tint application, grace value modification and maintain aspect ratio for slider icon 

### DIFF
--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -24,6 +24,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewOutlineProvider
 import android.view.animation.AnticipateOvershootInterpolator
+import android.view.animation.LinearInterpolator
 import android.view.animation.OvershootInterpolator
 import android.widget.TextView
 import androidx.annotation.ColorInt
@@ -672,7 +673,7 @@ class SlideToActView @JvmOverloads constructor(
             mActualAreaMargin = it.animatedValue as Int
             invalidate()
         }
-        marginAnimator.interpolator = AnticipateOvershootInterpolator(2f)
+        marginAnimator.interpolator = LinearInterpolator()
 
         // Animator that reduces the outer area (to right)
         val areaAnimator = ValueAnimator.ofInt(0, (mAreaWidth - mAreaHeight) / 2)

--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -8,11 +8,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.pm.PackageManager
 import android.content.res.TypedArray
-import android.graphics.Canvas
-import android.graphics.Outline
-import android.graphics.Paint
-import android.graphics.RectF
-import android.graphics.Typeface
+import android.graphics.*
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.VibrationEffect
@@ -47,9 +43,9 @@ import com.ncorti.slidetoact.SlideToActIconUtil.tintIconCompat
  *  with a "Slide-to-unlock" like widget.
  */
 class SlideToActView @JvmOverloads constructor(
-    context: Context,
-    xmlAttrs: AttributeSet? = null,
-    defStyleAttr: Int = R.attr.slideToActViewStyle
+        context: Context,
+        xmlAttrs: AttributeSet? = null,
+        defStyleAttr: Int = R.attr.slideToActViewStyle
 ) : View(context, xmlAttrs, defStyleAttr) {
 
     companion object {
@@ -156,7 +152,7 @@ class SlideToActView @JvmOverloads constructor(
         set(value) {
             field = value
             if (value != 0)
-            DrawableCompat.setTint(mDrawableArrow, value)
+                DrawableCompat.setTint(mDrawableArrow, value)
             invalidate()
         }
 
@@ -169,7 +165,7 @@ class SlideToActView @JvmOverloads constructor(
                 ResourcesCompat.getDrawable(context.resources, value, context.theme)?.let {
                     mDrawableArrow = it
                     if (iconColor != 0)
-                    DrawableCompat.setTint(it, iconColor)
+                        DrawableCompat.setTint(it, iconColor)
                 }
                 invalidate()
             }
@@ -259,13 +255,16 @@ class SlideToActView @JvmOverloads constructor(
 
     /** Inner rectangle (used for arrow rotation) */
     private var mInnerRect: RectF
+
     /** Outer rectangle (used for area drawing) */
     private var mOuterRect: RectF
+
     /** Grace value, when mPositionPerc > mGraceValue slider will perform the 'complete' operations */
-    private val mGraceValue: Float = 0.8F
+    var graceValue: Float = 0.8F
 
     /** Last X coordinate for the touch event */
     private var mLastX: Float = 0F
+
     /** Flag to understand if user is moving the slider cursor */
     private var mFlagMoving: Boolean = false
 
@@ -308,36 +307,36 @@ class SlideToActView @JvmOverloads constructor(
         mTextPaint = mTextView.paint
 
         val attrs: TypedArray = context.theme.obtainStyledAttributes(
-            xmlAttrs,
-            R.styleable.SlideToActView,
-            defStyleAttr,
-            R.style.SlideToActView
+                xmlAttrs,
+                R.styleable.SlideToActView,
+                defStyleAttr,
+                R.style.SlideToActView
         )
         try {
             mDesiredSliderHeight = TypedValue.applyDimension(
-                TypedValue.COMPLEX_UNIT_DIP,
-                mDesiredSliderHeightDp,
-                resources.displayMetrics
+                    TypedValue.COMPLEX_UNIT_DIP,
+                    mDesiredSliderHeightDp,
+                    resources.displayMetrics
             ).toInt()
             mDesiredSliderWidth = TypedValue.applyDimension(
-                TypedValue.COMPLEX_UNIT_DIP,
-                mDesiredSliderWidthDp,
-                resources.displayMetrics
+                    TypedValue.COMPLEX_UNIT_DIP,
+                    mDesiredSliderWidthDp,
+                    resources.displayMetrics
             ).toInt()
 
             val defaultOuter = ContextCompat.getColor(
-                this.context,
-                R.color.slidetoact_defaultAccent
+                    this.context,
+                    R.color.slidetoact_defaultAccent
             )
             val defaultWhite = ContextCompat.getColor(
-                this.context,
-                R.color.slidetoact_white
+                    this.context,
+                    R.color.slidetoact_white
             )
 
             with(attrs) {
                 mDesiredSliderHeight = getDimensionPixelSize(
-                    R.styleable.SlideToActView_slider_height,
-                    mDesiredSliderHeight
+                        R.styleable.SlideToActView_slider_height,
+                        mDesiredSliderHeight
                 )
                 mBorderRadius = getDimensionPixelSize(R.styleable.SlideToActView_border_radius, -1)
 
@@ -357,8 +356,8 @@ class SlideToActView @JvmOverloads constructor(
                 text = getString(R.styleable.SlideToActView_text) ?: ""
                 typeFace = getInt(R.styleable.SlideToActView_text_style, 0)
                 mTextSize = getDimensionPixelSize(
-                    R.styleable.SlideToActView_text_size,
-                    resources.getDimensionPixelSize(R.dimen.slidetoact_default_text_size)
+                        R.styleable.SlideToActView_text_size,
+                        resources.getDimensionPixelSize(R.dimen.slidetoact_default_text_size)
                 )
                 textColor = actualTextColor
 
@@ -369,21 +368,27 @@ class SlideToActView @JvmOverloads constructor(
                 isReversed = getBoolean(R.styleable.SlideToActView_slider_reversed, false)
                 isRotateIcon = getBoolean(R.styleable.SlideToActView_rotate_icon, true)
                 isAnimateCompletion = getBoolean(
-                    R.styleable.SlideToActView_animate_completion,
-                    true
+                        R.styleable.SlideToActView_animate_completion,
+                        true
                 )
+
+                graceValue = getFloat(
+                        R.styleable.SlideToActView_grace_value_percent,
+                        graceValue
+                )
+
                 animDuration = getInteger(
-                    R.styleable.SlideToActView_animation_duration,
-                    300
+                        R.styleable.SlideToActView_animation_duration,
+                        300
                 ).toLong()
                 bumpVibration = getInt(
-                    R.styleable.SlideToActView_bump_vibration,
-                    0
+                        R.styleable.SlideToActView_bump_vibration,
+                        0
                 ).toLong()
 
                 mOriginAreaMargin = getDimensionPixelSize(
-                    R.styleable.SlideToActView_area_margin,
-                    resources.getDimensionPixelSize(R.dimen.slidetoact_default_area_margin)
+                        R.styleable.SlideToActView_area_margin,
+                        resources.getDimensionPixelSize(R.dimen.slidetoact_default_area_margin)
                 )
                 mActualAreaMargin = mOriginAreaMargin
 
@@ -413,13 +418,13 @@ class SlideToActView @JvmOverloads constructor(
                     else -> defaultOuter
                 }
                 actualCompleteDrawable = getResourceId(
-                    R.styleable.SlideToActView_complete_icon,
-                    R.drawable.slidetoact_animated_ic_check
+                        R.styleable.SlideToActView_complete_icon,
+                        R.drawable.slidetoact_animated_ic_check
                 )
 
                 mIconMargin = getDimensionPixelSize(
-                    R.styleable.SlideToActView_icon_margin,
-                    resources.getDimensionPixelSize(R.dimen.slidetoact_default_icon_margin)
+                        R.styleable.SlideToActView_icon_margin,
+                        resources.getDimensionPixelSize(R.dimen.slidetoact_default_icon_margin)
                 )
 
                 mArrowMargin = mIconMargin
@@ -430,17 +435,17 @@ class SlideToActView @JvmOverloads constructor(
         }
 
         mInnerRect = RectF(
-            (mActualAreaMargin + mEffectivePosition).toFloat(),
-            mActualAreaMargin.toFloat(),
-            (mAreaHeight + mEffectivePosition).toFloat() - mActualAreaMargin.toFloat(),
-            mAreaHeight.toFloat() - mActualAreaMargin.toFloat()
+                (mActualAreaMargin + mEffectivePosition).toFloat(),
+                mActualAreaMargin.toFloat(),
+                (mAreaHeight + mEffectivePosition).toFloat() - mActualAreaMargin.toFloat(),
+                mAreaHeight.toFloat() - mActualAreaMargin.toFloat()
         )
 
         mOuterRect = RectF(
-            mActualAreaWidth.toFloat(),
-            0f,
-            mAreaWidth.toFloat() - mActualAreaWidth.toFloat(),
-            mAreaHeight.toFloat()
+                mActualAreaWidth.toFloat(),
+                0f,
+                mAreaWidth.toFloat() - mActualAreaWidth.toFloat(),
+                mAreaHeight.toFloat()
         )
 
         mDrawableTick = loadIconCompat(context, actualCompleteDrawable)
@@ -482,7 +487,7 @@ class SlideToActView @JvmOverloads constructor(
         // Text horizontal/vertical positioning (both centered)
         mTextXPosition = mAreaWidth.toFloat() / 2
         mTextYPosition = (mAreaHeight.toFloat() / 2) -
-            (mTextPaint.descent() + mTextPaint.ascent()) / 2
+                (mTextPaint.descent() + mTextPaint.ascent()) / 2
 
         // Make sure the position is recomputed.
         mPosition = 0
@@ -494,16 +499,16 @@ class SlideToActView @JvmOverloads constructor(
 
         // Outer area
         mOuterRect.set(
-            mActualAreaWidth.toFloat(),
-            0f,
-            mAreaWidth.toFloat() - mActualAreaWidth.toFloat(),
-            mAreaHeight.toFloat()
+                mActualAreaWidth.toFloat(),
+                0f,
+                mAreaWidth.toFloat() - mActualAreaWidth.toFloat(),
+                mAreaHeight.toFloat()
         )
         canvas.drawRoundRect(
-            mOuterRect,
-            mBorderRadius.toFloat(),
-            mBorderRadius.toFloat(),
-            mOuterPaint
+                mOuterRect,
+                mBorderRadius.toFloat(),
+                mBorderRadius.toFloat(),
+                mOuterPaint
         )
 
         // Text alpha
@@ -511,28 +516,28 @@ class SlideToActView @JvmOverloads constructor(
         // Checking if the TextView has a Transformation method applied (e.g. AllCaps).
         val textToDraw = mTextView.transformationMethod?.getTransformation(text, mTextView) ?: text
         canvas.drawText(
-            textToDraw,
-            0,
-            textToDraw.length,
-            mTextXPosition,
-            mTextYPosition,
-            mTextPaint
+                textToDraw,
+                0,
+                textToDraw.length,
+                mTextXPosition,
+                mTextYPosition,
+                mTextPaint
         )
 
         // Inner Cursor
         // ratio is used to compute the proper border radius for the inner rect (see #8).
         val ratio = (mAreaHeight - 2 * mActualAreaMargin).toFloat() / mAreaHeight.toFloat()
         mInnerRect.set(
-            (mActualAreaMargin + mEffectivePosition).toFloat(),
-            mActualAreaMargin.toFloat(),
-            (mAreaHeight + mEffectivePosition).toFloat() - mActualAreaMargin.toFloat(),
-            mAreaHeight.toFloat() - mActualAreaMargin.toFloat()
+                (mActualAreaMargin + mEffectivePosition).toFloat(),
+                mActualAreaMargin.toFloat(),
+                (mAreaHeight + mEffectivePosition).toFloat() - mActualAreaMargin.toFloat(),
+                mAreaHeight.toFloat() - mActualAreaMargin.toFloat()
         )
         canvas.drawRoundRect(
-            mInnerRect,
-            mBorderRadius.toFloat() * ratio,
-            mBorderRadius.toFloat() * ratio,
-            mInnerPaint
+                mInnerRect,
+                mBorderRadius.toFloat() * ratio,
+                mBorderRadius.toFloat() * ratio,
+                mInnerPaint
         )
 
         // Arrow angle
@@ -546,13 +551,13 @@ class SlideToActView @JvmOverloads constructor(
             canvas.rotate(mArrowAngle, mInnerRect.centerX(), mInnerRect.centerY())
         }
         mDrawableArrow.setBounds(
-            mInnerRect.left.toInt() + mArrowMargin,
-            mInnerRect.top.toInt() + mArrowMargin,
-            mInnerRect.right.toInt() - mArrowMargin,
-            mInnerRect.bottom.toInt() - mArrowMargin
+                mInnerRect.left.toInt() + mArrowMargin,
+                mInnerRect.top.toInt() + mArrowMargin,
+                mInnerRect.right.toInt() - mArrowMargin,
+                mInnerRect.bottom.toInt() - mArrowMargin
         )
         if (mDrawableArrow.bounds.left <= mDrawableArrow.bounds.right &&
-            mDrawableArrow.bounds.top <= mDrawableArrow.bounds.bottom
+                mDrawableArrow.bounds.top <= mDrawableArrow.bounds.bottom
         ) {
             mDrawableArrow.draw(canvas)
         }
@@ -560,9 +565,9 @@ class SlideToActView @JvmOverloads constructor(
 
         // Tick drawing
         mDrawableTick.setBounds(
-            mActualAreaWidth + mTickMargin,
-            mTickMargin,
-            mAreaWidth - mTickMargin - mActualAreaWidth,
+                mActualAreaWidth + mTickMargin,
+                mTickMargin,
+                mAreaWidth - mTickMargin - mActualAreaWidth,
                 mAreaHeight - mTickMargin
         )
 
@@ -600,7 +605,7 @@ class SlideToActView @JvmOverloads constructor(
                 MotionEvent.ACTION_UP -> {
                     parent.requestDisallowInterceptTouchEvent(false)
                     if ((mPosition > 0 && isLocked) ||
-                        (mPosition > 0 && mPositionPerc < mGraceValue)
+                            (mPosition > 0 && mPositionPerc < graceValue)
                     ) {
                         // Check for grace value
                         val positionAnimator = ValueAnimator.ofInt(mPosition, 0)
@@ -610,7 +615,7 @@ class SlideToActView @JvmOverloads constructor(
                             invalidate()
                         }
                         positionAnimator.start()
-                    } else if (mPosition > 0 && mPositionPerc >= mGraceValue) {
+                    } else if (mPosition > 0 && mPositionPerc >= graceValue) {
                         isEnabled = false // Fully disable touch events
                         startAnimationComplete()
                     } else if (mFlagMoving && mPosition == 0) {
@@ -651,11 +656,11 @@ class SlideToActView @JvmOverloads constructor(
      */
     private fun checkInsideButton(x: Float, y: Float): Boolean {
         return (
-            0 < y &&
-                y < mAreaHeight &&
-                mEffectivePosition < x &&
-                x < (mAreaHeight + mEffectivePosition)
-            )
+                0 < y &&
+                        y < mAreaHeight &&
+                        mEffectivePosition < x &&
+                        x < (mAreaHeight + mEffectivePosition)
+                )
     }
 
     /**
@@ -695,8 +700,8 @@ class SlideToActView @JvmOverloads constructor(
 
         // Animator that bounce away the cursors
         val marginAnimator = ValueAnimator.ofInt(
-            mActualAreaMargin,
-            (mInnerRect.width() / 2).toInt() + mActualAreaMargin
+                mActualAreaMargin,
+                (mInnerRect.width() / 2).toInt() + mActualAreaMargin
         )
         marginAnimator.addUpdateListener {
             mActualAreaMargin = it.animatedValue as Int
@@ -739,28 +744,28 @@ class SlideToActView @JvmOverloads constructor(
         animSet.duration = animDuration
 
         animSet.addListener(
-            object : Animator.AnimatorListener {
-                override fun onAnimationStart(p0: Animator?) {
-                    onSlideToActAnimationEventListener?.onSlideCompleteAnimationStarted(
-                        this@SlideToActView,
-                        mPositionPerc
-                    )
-                }
+                object : Animator.AnimatorListener {
+                    override fun onAnimationStart(p0: Animator?) {
+                        onSlideToActAnimationEventListener?.onSlideCompleteAnimationStarted(
+                                this@SlideToActView,
+                                mPositionPerc
+                        )
+                    }
 
-                override fun onAnimationCancel(p0: Animator?) {
-                }
+                    override fun onAnimationCancel(p0: Animator?) {
+                    }
 
-                override fun onAnimationEnd(p0: Animator?) {
-                    mIsCompleted = true
-                    onSlideToActAnimationEventListener?.onSlideCompleteAnimationEnded(
-                        this@SlideToActView
-                    )
-                    onSlideCompleteListener?.onSlideComplete(this@SlideToActView)
-                }
+                    override fun onAnimationEnd(p0: Animator?) {
+                        mIsCompleted = true
+                        onSlideToActAnimationEventListener?.onSlideCompleteAnimationEnded(
+                                this@SlideToActView
+                        )
+                        onSlideCompleteListener?.onSlideComplete(this@SlideToActView)
+                    }
 
-                override fun onAnimationRepeat(p0: Animator?) {
+                    override fun onAnimationRepeat(p0: Animator?) {
+                    }
                 }
-            }
         )
         animSet.start()
     }
@@ -842,11 +847,11 @@ class SlideToActView @JvmOverloads constructor(
 
         if (isAnimateCompletion) {
             animSet.playSequentially(
-                tickAnimator,
-                areaAnimator,
-                positionAnimator,
-                marginAnimator,
-                arrowAnimator
+                    tickAnimator,
+                    areaAnimator,
+                    positionAnimator,
+                    marginAnimator,
+                    arrowAnimator
             )
         } else {
             animSet.playSequentially(positionAnimator)
@@ -855,28 +860,28 @@ class SlideToActView @JvmOverloads constructor(
         animSet.duration = animDuration
 
         animSet.addListener(
-            object : Animator.AnimatorListener {
-                override fun onAnimationStart(p0: Animator?) {
-                    onSlideToActAnimationEventListener?.onSlideResetAnimationStarted(
-                        this@SlideToActView
-                    )
-                }
+                object : Animator.AnimatorListener {
+                    override fun onAnimationStart(p0: Animator?) {
+                        onSlideToActAnimationEventListener?.onSlideResetAnimationStarted(
+                                this@SlideToActView
+                        )
+                    }
 
-                override fun onAnimationCancel(p0: Animator?) {
-                }
+                    override fun onAnimationCancel(p0: Animator?) {
+                    }
 
-                override fun onAnimationEnd(p0: Animator?) {
-                    isEnabled = true
-                    stopIconAnimation(mDrawableTick)
-                    onSlideToActAnimationEventListener?.onSlideResetAnimationEnded(
-                        this@SlideToActView
-                    )
-                    onSlideResetListener?.onSlideReset(this@SlideToActView)
-                }
+                    override fun onAnimationEnd(p0: Animator?) {
+                        isEnabled = true
+                        stopIconAnimation(mDrawableTick)
+                        onSlideToActAnimationEventListener?.onSlideResetAnimationEnded(
+                                this@SlideToActView
+                        )
+                        onSlideResetListener?.onSlideReset(this@SlideToActView)
+                    }
 
-                override fun onAnimationRepeat(p0: Animator?) {
+                    override fun onAnimationRepeat(p0: Animator?) {
+                    }
                 }
-            }
         )
         animSet.start()
     }
@@ -890,13 +895,13 @@ class SlideToActView @JvmOverloads constructor(
         if (bumpVibration <= 0) return
 
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.VIBRATE) !=
-            PackageManager.PERMISSION_GRANTED
+                PackageManager.PERMISSION_GRANTED
         ) {
             Log.w(
-                TAG,
-                "bumpVibration is set but permissions are unavailable." +
-                    "You must have the permission android.permission.VIBRATE in " +
-                    "AndroidManifest.xml to use bumpVibration"
+                    TAG,
+                    "bumpVibration is set but permissions are unavailable." +
+                            "You must have the permission android.permission.VIBRATE in " +
+                            "AndroidManifest.xml to use bumpVibration"
             )
             return
         }
@@ -905,7 +910,7 @@ class SlideToActView @JvmOverloads constructor(
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             vibrator.vibrate(
-                VibrationEffect.createOneShot(bumpVibration, VibrationEffect.DEFAULT_AMPLITUDE)
+                    VibrationEffect.createOneShot(bumpVibration, VibrationEffect.DEFAULT_AMPLITUDE)
             )
         } else {
             vibrator.vibrate(bumpVibration)
@@ -1008,11 +1013,11 @@ class SlideToActView @JvmOverloads constructor(
             if (view == null || outline == null) return
 
             outline.setRoundRect(
-                mActualAreaWidth,
-                0,
-                mAreaWidth - mActualAreaWidth,
-                mAreaHeight,
-                mBorderRadius.toFloat()
+                    mActualAreaWidth,
+                    0,
+                    mAreaWidth - mActualAreaWidth,
+                    mAreaHeight,
+                    mBorderRadius.toFloat()
             )
         }
     }

--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -391,7 +391,7 @@ class SlideToActView @JvmOverloads constructor(
                 actualStrokeInnerColor = getColor(R.styleable.SlideToActView_inner_stroke_color, -1)
                 actualStrokeOuterColor = getColor(R.styleable.SlideToActView_outer_stroke_color, -1)
 
-                  actualStrokeInnerWidth = getDimension(R.styleable.SlideToActView_inner_stroke_width, defaultStrokeWidth)
+                actualStrokeInnerWidth = getDimension(R.styleable.SlideToActView_inner_stroke_width, defaultStrokeWidth)
                 actualStrokeOuterWidth = getDimension(R.styleable.SlideToActView_outer_stroke_width, defaultStrokeWidth)
 
                 // For text color, check if the `text_color` is set.
@@ -654,17 +654,15 @@ class SlideToActView @JvmOverloads constructor(
             mArrowAngle = -180 * mPositionPerc
             canvas.rotate(mArrowAngle, mInnerRect.centerX(), mInnerRect.centerY())
         }
-        mDrawableArrow.setBounds(
-                mInnerRect.left.toInt() + mArrowMargin,
-                mInnerRect.top.toInt() + mArrowMargin,
-                mInnerRect.right.toInt() - mArrowMargin,
-                mInnerRect.bottom.toInt() - mArrowMargin
-        )
+
+        createCropBounds(mDrawableArrow,mInnerRect,mArrowMargin)
+
         if (mDrawableArrow.bounds.left <= mDrawableArrow.bounds.right &&
                 mDrawableArrow.bounds.top <= mDrawableArrow.bounds.bottom
         ) {
             mDrawableArrow.draw(canvas)
         }
+
         canvas.restore()
 
         // Tick drawing
@@ -681,6 +679,33 @@ class SlideToActView @JvmOverloads constructor(
         if (mFlagDrawTick) {
             mDrawableTick.draw(canvas)
         }
+    }
+
+    private fun createCropBounds(drawable: Drawable,rect:RectF,margin:Int) {
+        val proportion = drawable.intrinsicWidth / drawable.intrinsicHeight.toFloat()
+        val width = rect.right.toInt() - margin * 2 - rect.left.toInt()
+        val height = rect.bottom.toInt() - margin * 2 - rect.top.toInt()
+        val proportionWidth: Int
+        val proportionHeight: Int
+
+        if (proportion >= 1) {
+            proportionHeight = (width * 1 / proportion).toInt()
+            proportionWidth = width
+        } else {
+            proportionHeight = height
+            proportionWidth = (height * proportion).toInt()
+        }
+
+        val left = rect.left.toInt() + margin + width / 2 - proportionWidth / 2
+        val top = rect.top.toInt() + margin + height / 2 - proportionHeight / 2
+        val right = rect.left.toInt() + margin + width / 2 + proportionWidth / 2
+        val bottom = rect.top.toInt() + margin + height / 2 + proportionHeight / 2
+        drawable.setBounds(
+                left,
+                top,
+                right,
+                bottom
+        )
     }
 
     // Intentionally override `performClick` to do not lose accessibility support.

--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -83,6 +83,10 @@ class SlideToActView @JvmOverloads constructor(
 
     /** Enable default icon tint for slider **/
     var enableSliderIconTint: Boolean = true
+
+    /** Enable default icon tint for completion **/
+    var enableCompleteIconTint: Boolean = true
+
     /** Text message */
     var text: CharSequence = ""
         set(value) {
@@ -216,8 +220,10 @@ class SlideToActView @JvmOverloads constructor(
 
     /** Margin for Arrow Icon */
     private var mArrowMargin: Int
+
     /** Current angle for Arrow Icon */
     private var mArrowAngle: Float = 0f
+
     /** Margin for Tick Icon */
     private var mTickMargin: Int
 
@@ -386,9 +392,14 @@ class SlideToActView @JvmOverloads constructor(
                         true
                 )
 
+                enableCompleteIconTint = getBoolean(
+                        R.styleable.SlideToActView_enable_tint_complete_icon,
+                        true
+                )
+
                 sliderIcon = getResourceId(
-                    R.styleable.SlideToActView_slider_icon,
-                    R.drawable.slidetoact_ic_arrow
+                        R.styleable.SlideToActView_slider_icon,
+                        R.drawable.slidetoact_ic_arrow
                 )
 
                 // For icon color. check if the `slide_icon_color` is set.
@@ -552,10 +563,12 @@ class SlideToActView @JvmOverloads constructor(
             mActualAreaWidth + mTickMargin,
             mTickMargin,
             mAreaWidth - mTickMargin - mActualAreaWidth,
-            mAreaHeight - mTickMargin
+                mAreaHeight - mTickMargin
         )
 
-        tintIconCompat(mDrawableTick, innerColor)
+        if(enableCompleteIconTint)
+            tintIconCompat(mDrawableTick, innerColor)
+
         if (mFlagDrawTick) {
             mDrawableTick.draw(canvas)
         }

--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -67,16 +67,22 @@ class SlideToActView @JvmOverloads constructor(
 
     /** Height of the drawing area */
     private var mAreaHeight: Int = 0
+
     /** Width of the drawing area */
     private var mAreaWidth: Int = 0
+
     /** Actual Width of the drawing area, used for animations */
     private var mActualAreaWidth: Int = 0
+
     /** Border Radius, default to mAreaHeight/2, -1 when not initialized */
     private var mBorderRadius: Int = -1
+
     /** Margin of the cursor from the outer area */
     private var mActualAreaMargin: Int
     private val mOriginAreaMargin: Int
 
+    /** Enable default icon tint for slider **/
+    var enableSliderIconTint: Boolean = true
     /** Text message */
     var text: CharSequence = ""
         set(value) {
@@ -145,6 +151,7 @@ class SlideToActView @JvmOverloads constructor(
     var iconColor: Int = 0
         set(value) {
             field = value
+            if (value != 0)
             DrawableCompat.setTint(mDrawableArrow, value)
             invalidate()
         }
@@ -157,6 +164,7 @@ class SlideToActView @JvmOverloads constructor(
             if (field != 0) {
                 ResourcesCompat.getDrawable(context.resources, value, context.theme)?.let {
                     mDrawableArrow = it
+                    if (iconColor != 0)
                     DrawableCompat.setTint(it, iconColor)
                 }
                 invalidate()
@@ -198,12 +206,14 @@ class SlideToActView @JvmOverloads constructor(
 
     /** Slider cursor position in percentage (between 0f and 1f) */
     private var mPositionPerc: Float = 0f
+
     /** 1/mPositionPerc */
     private var mPositionPercInv: Float = 1f
 
     /* -------------------- ICONS -------------------- */
 
     private val mIconMargin: Int
+
     /** Margin for Arrow Icon */
     private var mArrowMargin: Int
     /** Current angle for Arrow Icon */
@@ -371,6 +381,11 @@ class SlideToActView @JvmOverloads constructor(
                 )
                 mActualAreaMargin = mOriginAreaMargin
 
+                enableSliderIconTint = getBoolean(
+                        R.styleable.SlideToActView_enable_tint_slider_icon,
+                        true
+                )
+
                 sliderIcon = getResourceId(
                     R.styleable.SlideToActView_slider_icon,
                     R.drawable.slidetoact_ic_arrow
@@ -380,6 +395,7 @@ class SlideToActView @JvmOverloads constructor(
                 // if not check if the `outer_color` is set.
                 // if not, default to defaultOuter.
                 actualIconColor = when {
+                    !enableSliderIconTint -> 0
                     hasValue(R.styleable.SlideToActView_slider_icon_color) ->
                         getColor(R.styleable.SlideToActView_slider_icon_color, defaultOuter)
                     hasValue(R.styleable.SlideToActView_outer_color) -> actualOuterColor

--- a/slidetoact/src/main/res/values/attrs.xml
+++ b/slidetoact/src/main/res/values/attrs.xml
@@ -21,6 +21,7 @@
         <attr name="slider_reversed" format="boolean" />
         <attr name="slider_icon" format="reference" />
         <attr name="enable_tint_slider_icon" format="boolean" />
+        <attr name="enable_tint_complete_icon" format="boolean" />
         <attr name="slider_icon_color" format="color" />
         <attr name="rotate_icon" format="boolean" />
         <attr name="animate_completion" format="boolean" />

--- a/slidetoact/src/main/res/values/attrs.xml
+++ b/slidetoact/src/main/res/values/attrs.xml
@@ -20,6 +20,7 @@
         <attr name="slider_locked" format="boolean" />
         <attr name="slider_reversed" format="boolean" />
         <attr name="slider_icon" format="reference" />
+        <attr name="enable_tint_slider_icon" format="boolean" />
         <attr name="slider_icon_color" format="color" />
         <attr name="rotate_icon" format="boolean" />
         <attr name="animate_completion" format="boolean" />

--- a/slidetoact/src/main/res/values/attrs.xml
+++ b/slidetoact/src/main/res/values/attrs.xml
@@ -15,6 +15,7 @@
         <attr name="text_color" format="color" />
         <attr name="border_radius" format="dimension" />
         <attr name="slider_height" format="dimension" />
+        <attr name="grace_value_percent" format="float" />
         <attr name="animation_duration" format="integer" />
         <attr name="bump_vibration" format="integer" />
         <attr name="slider_locked" format="boolean" />

--- a/slidetoact/src/main/res/values/attrs.xml
+++ b/slidetoact/src/main/res/values/attrs.xml
@@ -11,7 +11,11 @@
         <attr name="area_margin" format="dimension" />
         <attr name="icon_margin" format="dimension" />
         <attr name="inner_color" format="color" />
+        <attr name="inner_stroke_color" format="color" />
+        <attr name="inner_stroke_width" format="dimension" />
         <attr name="outer_color" format="color" />
+        <attr name="outer_stroke_color" format="color" />
+        <attr name="outer_stroke_width" format="dimension" />
         <attr name="text_color" format="color" />
         <attr name="border_radius" format="dimension" />
         <attr name="slider_height" format="dimension" />

--- a/slidetoact/src/main/res/values/dimens.xml
+++ b/slidetoact/src/main/res/values/dimens.xml
@@ -1,5 +1,6 @@
 <resources>
     <dimen name="slidetoact_default_area_margin">8dp</dimen>
+    <dimen name="slidetoact_default_stroke_width">3dp</dimen>
     <dimen name="slidetoact_default_icon_margin">16dp</dimen>
     <dimen name="slidetoact_default_text_size">16sp</dimen>
 </resources>


### PR DESCRIPTION
Change AnticipateOvershootInterpolar to LinearInterpolator to avoid weird animation effect when slider dissappear on completion

Enable/disable option for slider icon tint

Enable/disable option for complete icon tint

Added property to modify grace slide value

Added attributes for stroke width and color configuration on xml files

Crop slider icon image to maintain aspect ratio