### PR TITLE
Adds missing dynamic height adjustment capability

### DIFF
--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -458,10 +458,7 @@ class SlideToActView @JvmOverloads constructor(
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         mAreaWidth = w
         mAreaHeight = h
-//        if (mBorderRadius == -1) {
-            // Round if not set up
-            mBorderRadius = h / 2
-//        }
+        mBorderRadius = h / 2
 
         // Text horizontal/vertical positioning (both centered)
         mTextXPosition = mAreaWidth.toFloat() / 2

--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -444,7 +444,6 @@ class SlideToActView @JvmOverloads constructor(
             MeasureSpec.UNSPECIFIED -> mDesiredSliderWidth
             else -> mDesiredSliderWidth
         }
-        setMeasuredDimension(width, mDesiredSliderHeight)
 
         height = when (heightMode) {
             MeasureSpec.EXACTLY -> heightSize
@@ -452,6 +451,7 @@ class SlideToActView @JvmOverloads constructor(
             MeasureSpec.UNSPECIFIED -> mDesiredSliderHeight
             else -> mDesiredSliderHeight
         }
+
         setMeasuredDimension(width, height)
     }
 

--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -317,7 +317,6 @@ class SlideToActView @JvmOverloads constructor(
                 R.color.slidetoact_white
             )
 
-
             with(attrs) {
                 mDesiredSliderHeight = getDimensionPixelSize(
                     R.styleable.SlideToActView_slider_height,

--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -317,6 +317,7 @@ class SlideToActView @JvmOverloads constructor(
                 R.color.slidetoact_white
             )
 
+
             with(attrs) {
                 mDesiredSliderHeight = getDimensionPixelSize(
                     R.styleable.SlideToActView_slider_height,
@@ -434,6 +435,10 @@ class SlideToActView @JvmOverloads constructor(
         val widthSize = MeasureSpec.getSize(widthMeasureSpec)
         val width: Int
 
+        val heightMode = MeasureSpec.getMode(heightMeasureSpec)
+        val heightSize = MeasureSpec.getSize(heightMeasureSpec)
+        val height: Int
+
         width = when (widthMode) {
             MeasureSpec.EXACTLY -> widthSize
             MeasureSpec.AT_MOST -> Math.min(mDesiredSliderWidth, widthSize)
@@ -441,15 +446,23 @@ class SlideToActView @JvmOverloads constructor(
             else -> mDesiredSliderWidth
         }
         setMeasuredDimension(width, mDesiredSliderHeight)
+
+        height = when (heightMode) {
+            MeasureSpec.EXACTLY -> heightSize
+            MeasureSpec.AT_MOST -> Math.min(mDesiredSliderHeight, heightSize)
+            MeasureSpec.UNSPECIFIED -> mDesiredSliderHeight
+            else -> mDesiredSliderHeight
+        }
+        setMeasuredDimension(width, height)
     }
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         mAreaWidth = w
         mAreaHeight = h
-        if (mBorderRadius == -1) {
+//        if (mBorderRadius == -1) {
             // Round if not set up
             mBorderRadius = h / 2
-        }
+//        }
 
         // Text horizontal/vertical positioning (both centered)
         mTextXPosition = mAreaWidth.toFloat() / 2


### PR DESCRIPTION
## Description
The current version of SlideToAct cannot automatically adjust to the available space in the vertical direction.

This results in the LinearLayout, depending on the number of views displayed, or depending on the device resolution, that not all views can be fully displayed, or free space remains unused.

![02-SlideToAct-OriginalBehaviour-NotEnoughPlaceForAllSliders](https://user-images.githubusercontent.com/48684913/167250238-d23578a3-fa65-4c4f-8b1a-190f4af449ce.png)
**- Picture 1 -**

This extension adds the missing dynamic height adjustment capability to SlideToAct.

With this change, the SlideToAct sliders adapt their height automatically
![03-SlideToAct-Correction1-LessSpace](https://user-images.githubusercontent.com/48684913/167250303-966bbae7-ffe6-46a8-b7a6-304d4b003522.png)
**- Picture 2 -**

Two modification are made here:

1. in "`onMeasure()`" the dynamic height adjustment capability is added.
2. in "`onSizeChanged()`" the condition "`if (mBorderRadius == -1)`" is removed.

Modification 2 corrects the problem that when more free space becomes available, i.e. when SlideToAct becomes higher, the radius is not reapplied.
For Example: As a result, the slide button does not remain round, but becomes a square with rounded corners. (See picture beloy)

![04-SlideToAct-Correction1-MoreSpace-RadiusNotWorking](https://user-images.githubusercontent.com/48684913/167250367-67d97d80-2aea-4180-8684-5716730fc9d6.png)
**- Picture 3 -**

After modification 2 the radius calculation works. (See picture below)

![05-SlideToAct-Correction2-MoreSpace-RadiusWorking-CircleButtonSlider](https://user-images.githubusercontent.com/48684913/167250428-c2993024-ca17-420f-9a97-7ab7eccb4b0f.png)
**- Picture 4 -**

## Todos
- [x] Tests (Unit tests of the original master branch have been done + Own demo app, see pictures)
- [x] Documentation (The description from above)
- [x] Screenshots