### PR TITLE
Fix incorrect resetSlider deprecation message

### DIFF
--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -848,7 +848,7 @@ class SlideToActView @JvmOverloads constructor(
      * @deprecated Method that resets the slider
      */
     @Deprecated(
-        message = "Use setCompleted(completed: true, withAnimation: true) instead.",
+        message = "Use setCompleted(completed: false, withAnimation: true) instead.",
         replaceWith = ReplaceWith("setCompleted(completed: false, withAnimation: true)")
     )
     fun resetSlider() {


### PR DESCRIPTION
## Description
Stumbled upon an (probably copy-paste) error in the resetSlider method deprecation annotation message.

## Related PRs/Issues

None

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Screenshots