### PR TITLE
Bump compileSdk and targetSdk to 33

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -3,11 +3,11 @@ plugins {
 }
 
 android {
-    compileSdk = 32
+    compileSdk = 33
     defaultConfig {
         applicationId = "com.ncorti.slidetoact.example"
         minSdk = 14
-        targetSdk = 32
+        targetSdk = 33
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -15,6 +15,7 @@ android {
     lint {
         abortOnError = true
     }
+    namespace = "com.ncorti.slidetoact.example"
 }
 
 dependencies {

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:tools="http://schemas.android.com/tools"
-    package="com.ncorti.slidetoact.example"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.VIBRATE"/>

--- a/slidetoact/build.gradle.kts
+++ b/slidetoact/build.gradle.kts
@@ -10,12 +10,12 @@ version = "0.10.0".plus(if (hasProperty("USE_SNAPSHOT")) "-SNAPSHOT" else "")
 group = "com.ncorti"
 
 android {
-    compileSdk = 32
+    compileSdk = 33
     namespace = "com.ncorti.slidetoact"
 
     defaultConfig {
         minSdk = 14
-        targetSdk = 32
+        targetSdk = 33
         vectorDrawables.useSupportLibrary = true
     }
     lint {

--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -738,17 +738,17 @@ class SlideToActView @JvmOverloads constructor(
 
         animSet.addListener(
             object : Animator.AnimatorListener {
-                override fun onAnimationStart(p0: Animator?) {
+                override fun onAnimationStart(p0: Animator) {
                     onSlideToActAnimationEventListener?.onSlideCompleteAnimationStarted(
                         this@SlideToActView,
                         mPositionPerc
                     )
                 }
 
-                override fun onAnimationCancel(p0: Animator?) {
+                override fun onAnimationCancel(p0: Animator) {
                 }
 
-                override fun onAnimationEnd(p0: Animator?) {
+                override fun onAnimationEnd(p0: Animator) {
                     mIsCompleted = true
                     onSlideToActAnimationEventListener?.onSlideCompleteAnimationEnded(
                         this@SlideToActView
@@ -756,7 +756,7 @@ class SlideToActView @JvmOverloads constructor(
                     onSlideCompleteListener?.onSlideComplete(this@SlideToActView)
                 }
 
-                override fun onAnimationRepeat(p0: Animator?) {
+                override fun onAnimationRepeat(p0: Animator) {
                 }
             }
         )
@@ -930,16 +930,16 @@ class SlideToActView @JvmOverloads constructor(
 
         animSet.addListener(
             object : Animator.AnimatorListener {
-                override fun onAnimationStart(p0: Animator?) {
+                override fun onAnimationStart(p0: Animator) {
                     onSlideToActAnimationEventListener?.onSlideResetAnimationStarted(
                         this@SlideToActView
                     )
                 }
 
-                override fun onAnimationCancel(p0: Animator?) {
+                override fun onAnimationCancel(p0: Animator) {
                 }
 
-                override fun onAnimationEnd(p0: Animator?) {
+                override fun onAnimationEnd(p0: Animator) {
                     isEnabled = true
                     stopIconAnimation(mDrawableTick)
                     onSlideToActAnimationEventListener?.onSlideResetAnimationEnded(
@@ -948,7 +948,7 @@ class SlideToActView @JvmOverloads constructor(
                     onSlideResetListener?.onSlideReset(this@SlideToActView)
                 }
 
-                override fun onAnimationRepeat(p0: Animator?) {
+                override fun onAnimationRepeat(p0: Animator) {
                 }
             }
         )


### PR DESCRIPTION
## Description
Bumping `compileSdk` and `targetSdk` to 33

**Considerations**
- Bumped the `compileSdk` and `targetSdk` to 33
- Moved package from Android manifest to build file [Reference](https://developer.android.com/r/tools/upgrade-assistant/manifest-package-deprecated)
- Made parameters of `Animator.AnimatorListener`'s methods non null [Reference](https://developer.android.com/reference/android/animation/Animator.AnimatorListener)

## Related PRs/Issues
None

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Screenshots