### PR TITLE
Prepare the project for 0.12

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -34,7 +34,7 @@ jobs:
           name: 'release-artifacts'
           path: '~/.m2/repository/'
 
-      - name: Publish to the Snapshot Repository
+      - name: Publish to the Staging Repository
         run: ./gradlew publishReleasePublicationToNexusRepository
         env:
           ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -7,7 +7,6 @@ android {
     defaultConfig {
         applicationId = "com.ncorti.slidetoact.example"
         minSdk = 14
-        targetSdk = 33
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/slidetoact/build.gradle.kts
+++ b/slidetoact/build.gradle.kts
@@ -1,5 +1,3 @@
-
-
 plugins {
     id("com.android.library")
     id("maven-publish")
@@ -8,7 +6,7 @@ plugins {
     kotlin("android")
 }
 
-version = "0.11.0".plus(if (hasProperty("USE_SNAPSHOT")) "-SNAPSHOT" else "")
+version = "0.12.0".plus(if (hasProperty("USE_SNAPSHOT")) "-SNAPSHOT" else "")
 group = "com.ncorti"
 
 android {
@@ -17,7 +15,6 @@ android {
 
     defaultConfig {
         minSdk = 14
-        targetSdk = 33
         vectorDrawables.useSupportLibrary = true
     }
     lint {


### PR DESCRIPTION
## Description
Getting ready for the next release:
* Bumped version to 0.12.0 so snapshots are published as `0.12.0-SNAPSHOT`
* Removed `targetSdk` as deprecated
* Updated publishing workflow label as it was wrong