### PR TITLE
Update README to mention `bounce_repeat` instead of `bounce_repeat_count`

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ sta.setCompleted(completed: true, withAnimation: false);
 
 You can enable a bounce animation for the slider when the view is first rendered by setting the ``bounce_on_start`` attribute to true (default is false)
 Also you can set the duration of the bounce animation by setting the ``bounce_duration`` attribute (default is 2000)
-and repeat count by setting the ``bounce_repeat_count`` attribute (default is INFINITE)
+and repeat count by setting the ``bounce_repeat`` attribute (default is INFINITE)
 
 <p align="center">
   <img src="assets/bounce_on_start.gif" alt="bounce on start gif"/>


### PR DESCRIPTION
## Description

`bounce_repeat_count` at https://github.com/cortinico/slidetoact?tab=readme-ov-file#bounce_on_start is incorrect.

<img width="832" alt="Screenshot 2024-03-19 at 3 24 40 PM" src="https://github.com/cortinico/slidetoact/assets/4394910/71cea562-5c31-407b-9349-786ab9db8aad">

It should read `bounce_repeat`

<img width="611" alt="Screenshot 2024-03-19 at 3 25 32 PM" src="https://github.com/cortinico/slidetoact/assets/4394910/c45f7a38-03d2-4d49-8aad-222c11c43070">


## Related PRs/Issues

None

## Todos
- [ ] Tests
- [x] Documentation
- [ ] Screenshots