### PR TITLE
Expose Slider Cursor Position for Better Control

### DIFF
--- a/example/src/main/java/com/ncorti/slidetoact/example/MainActivity.java
+++ b/example/src/main/java/com/ncorti/slidetoact/example/MainActivity.java
@@ -4,6 +4,8 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
+
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -55,6 +57,16 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     public void onClick(View view) {
         Intent intent = new Intent(MainActivity.this, SampleActivity.class);
         intent.putExtra(SampleActivity.EXTRA_PRESSED_BUTTON, view.getId());
-        startActivity(intent);
+
+        int position =
+                ((SlideToActView) findViewById(R.id.welcome_slider)).getSliderCursorPosition();
+        Log.e("SlideToActView", "Position: " + position);
+        boolean isCompleted = ((SlideToActView) findViewById(R.id.welcome_slider)).isCompleted();
+        if (position == 0 || isCompleted) {
+            startActivity(intent);
+        } else {
+            Log.e("SlideToActView", "Oops! Please wait for slider to reset to Zero | Position: " + position);
+        }
+
     }
 }

--- a/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
+++ b/slidetoact/src/main/java/com/ncorti/slidetoact/SlideToActView.kt
@@ -172,6 +172,16 @@ class SlideToActView
                 }
             }
 
+        /**
+         * Retrieves the current position of the slider cursor.
+         *
+         * @return The current position of the slider cursor as an integer.
+         * @see getSliderCursorPosition
+         */
+        fun getSliderCursorPosition(): Int {
+            return mPosition
+        }
+
         /** Slider cursor position (between 0 and (`mAreaWidth - mAreaHeight)) */
         private var mPosition: Int = 0
             set(value) {


### PR DESCRIPTION
This PR introduces the `getSliderCursorPosition()` method, allowing developers to retrieve the current position of the slider cursor in SlideToActView.

## Description
By exposing this value, developers gain more control over the slider’s state, enabling various use cases such as:

- Preventing navigation while the slider is still animating.
- Tracking user progress on the slider.
- Implementing custom behaviors based on the slider’s position.

## Changes:
Added fun getSliderCursorPosition(): Int to expose the slider’s current position.

## Usage Example:

```java
@Override
public void onClick(View view) {
    Intent intent = new Intent(MainActivity.this, SampleActivity.class);
    intent.putExtra(SampleActivity.EXTRA_PRESSED_BUTTON, view.getId());

    int position = ((SlideToActView) findViewById(R.id.welcome_slider)).getSliderCursorPosition();
    Log.e("SlideToActView", "Position: " + position);

    boolean isCompleted = ((SlideToActView) findViewById(R.id.welcome_slider)).isCompleted();

    if (position == 0 || isCompleted) {
        startActivity(intent);
    } else {
        Log.e("SlideToActView", "Oops! Please wait for slider to reset to Zero | Position: " + position);
    }
}
```
